### PR TITLE
tests: ignore missing direct URL Origin of the distribution

### DIFF
--- a/tests/test_subprocess.py
+++ b/tests/test_subprocess.py
@@ -18,7 +18,10 @@ from tests.conftest import unix_sockets_only
 
 def is_pytest_socket_editably_installed() -> bool:
     pytest_socket_package = Distribution.from_name("pytest_subket")
-    direct_url = json.loads(pytest_socket_package.read_text("direct_url.json"))
+    direct_url_text = pytest_socket_package.read_text("direct_url.json")
+    if direct_url_text is None:
+        return False
+    direct_url = json.loads(direct_url_text)
     editable = direct_url.get("dir_info", {}).get("editable", False)
     if editable and "CI" in os.environ:
         raise RuntimeError("CI should be testing against a normal install")


### PR DESCRIPTION
According to the specification
(https://packaging.python.org/en/latest/specifications/direct-url/) `direct_url.json` may not exist on file system.

Fixes:
```
==================================== ERRORS ==================================== __________________ ERROR collecting tests/test_subprocess.py ___________________
tests/test_subprocess.py:30: in <module>
    is_pytest_socket_editably_installed(),
tests/test_subprocess.py:21: in is_pytest_socket_editably_installed
    direct_url = json.loads(pytest_socket_package.read_text("direct_url.json"))
/usr/lib64/python3.12/json/__init__.py:339: in loads
    raise TypeError(f'the JSON object must be str, bytes or bytearray, '
E   TypeError: the JSON object must be str, bytes or bytearray, not NoneType
=========================== short test summary info ============================
ERROR tests/test_subprocess.py - TypeError: the JSON object must be str, byte...
!!!!!!!!!!!!!!!!!!!! Interrupted: 1 error during collection !!!!!!!!!!!!!!!!!!!!
=============================== 1 error in 0.14s ===============================
```

Fixes: https://github.com/ichard26/pytest-subket/issues/3